### PR TITLE
Update zlib.h

### DIFF
--- a/zlib.h
+++ b/zlib.h
@@ -31,6 +31,7 @@
 */
 
 #include <stdint.h>
+#include <stdarg.h>
 #include "zconf.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fix build error "zlib.h:1819:66: error: unknown type name 'va_list'
 ZEXTERN int ZEXPORTVA gzvprintf(gzFile file, const char *format, va_list va);"
on gcc 7.3.1 (Centos 7)